### PR TITLE
Addresses https://github.com/JamesPHoughton/pysd/issues/80

### DIFF
--- a/pysd/pysd.py
+++ b/pysd/pysd.py
@@ -23,6 +23,7 @@ import imp
 import time
 import utils
 import tabulate
+import warnings
 
 from documentation import SDVarDoc
 
@@ -282,6 +283,9 @@ class PySD(object):
                 func_name = key
             else:
                 raise NameError('%s is not recognized as a model component' % key)
+
+            if func_name in self.components._stocknames:    # warn when setting stock values using params
+                warnings.warn("Replacing the equation of stock {} with params".format(key))
 
             setattr(self.components, func_name, new_function)
             self.components._funcs[func_name] = new_function  # facilitates lookups


### PR DESCRIPTION
Added warning to set_components when used with stocks
(just warning because it is actually a good way to analyse models by overriding stock values to constants)
Added test_set_component_warnings
Moved the test_py_model_file and test_mdl_file under class TestPySD