### PR TITLE
Addresses https://github.com/JamesPHoughton/pysd/issues/80

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,7 +10,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7.11 (~/anaconda/bin/python)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7.12 (C:\Users\Lumo\Anaconda2\python.exe)" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="1" />
   </component>

--- a/.idea/pysd.iml
+++ b/.idea/pysd.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 2.7.11 (~/anaconda/bin/python)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 2.7.12 (C:\Users\Lumo\Anaconda2\python.exe)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PackageRequirementsSettings">

--- a/pysd/pysd.py
+++ b/pysd/pysd.py
@@ -23,6 +23,7 @@ import imp
 import time
 import utils
 import tabulate
+import warnings
 
 from documentation import SDVarDoc
 
@@ -282,6 +283,9 @@ class PySD(object):
                 func_name = key
             else:
                 raise NameError('%s is not recognized as a model component' % key)
+
+            if func_name in self.components._stocknames:    # warn when setting stock values using params
+                warnings.warn("Replacing the equation of stock {} with params".format(key))
 
             setattr(self.components, func_name, new_function)
             self.components._funcs[func_name] = new_function  # facilitates lookups

--- a/pysd/pysd.py
+++ b/pysd/pysd.py
@@ -285,7 +285,7 @@ class PySD(object):
                 raise NameError('%s is not recognized as a model component' % key)
 
             if func_name in self.components._stocknames:    # warn when setting stock values using params
-                warnings.warn("Replacing the equation of stock {} with params".format(key))
+                warnings.warn("Replacing the equation of stock {} with params".format(key), stacklevel=2)
 
             setattr(self.components, func_name, new_function)
             self.components._funcs[func_name] = new_function  # facilitates lookups

--- a/tests/unit_test_pysd.py
+++ b/tests/unit_test_pysd.py
@@ -1,7 +1,6 @@
 import unittest
 import pandas as pd
 import numpy as np
-import warnings
 from pysd import utils
 
 test_model = 'test-models/samples/teacup/teacup.mdl'
@@ -118,14 +117,13 @@ class TestPySD(unittest.TestCase):
     def test_set_components_warnings(self):
         """Addresses https://github.com/JamesPHoughton/pysd/issues/80"""
         import pysd
+        import warnings
         model = pysd.read_vensim(test_model)
-
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            model.run(params={'Teacup Temperature': 20})   # run model while setting stock value using params
             model.set_components({'Teacup Temperature': 20, 'Characteristic Time': 15})   # set stock value using params
-        self.assertEqual(len(w), 2)
-        self.assertTrue('Teacup Temperature' in str(w[1].message))   # check that warning references the stock
+        self.assertEqual(len(w), 1)
+        self.assertTrue('Teacup Temperature' in str(w[0].message))   # check that warning references the stock
 
     def test_docs(self):
         """ Test that the model prints some documentation """


### PR DESCRIPTION
Added warning to set_components when used with stocks
(just warning because it is actually an easy way to analyse models by overriding stock values to constants)
Added test_set_components_warnings
Moved the test_py_model_file and test_mdl_file under class TestPySD