### PR TITLE
Continue work on xmile parsing and running

### DIFF
--- a/pysd/py_backend/functions.py
+++ b/pysd/py_backend/functions.py
@@ -19,6 +19,7 @@ import warnings
 import random
 import xarray as xr
 from funcsigs import signature
+import os
 
 try:
     import scipy.stats as stats
@@ -267,7 +268,7 @@ class Macro(Stateful):
         self.time = None
 
         # need a unique identifier for the imported module.
-        module_name = py_model_file + str(random.randint(0, 1000000))
+        module_name = os.path.splitext(py_model_file)[0] + str(random.randint(0, 1000000))
         self.components = imp.load_source(module_name,
                                           py_model_file)
 

--- a/pysd/py_backend/vensim/vensim2py.py
+++ b/pysd/py_backend/vensim/vensim2py.py
@@ -314,6 +314,150 @@ def parse_units(units_str):
     return units_str
 
 
+functions = {
+        # element-wise functions
+        "abs": "abs", 
+        "integer": "int", 
+        "exp": "np.exp", 
+        "sin": "np.sin", 
+        "cos": "np.cos",
+        "sqrt": "np.sqrt", 
+        "tan": "np.tan", 
+        "lognormal": "np.random.lognormal",
+        "random normal": 
+        "functions.bounded_normal", 
+        "poisson": "np.random.poisson",
+        "ln": "np.log", 
+        "log": "functions.log",
+        "exprnd": "np.random.exponential", 
+        "random uniform": "functions.random_uniform",
+        "sum": "np.sum",
+        "arccos": "np.arccos", 
+        "arcsin": "np.arcsin", 
+        "arctan": "np.arctan",
+        "if then else": "functions.if_then_else", 
+        "step": "functions.step", 
+        "modulo": "np.mod",
+        "pulse": "functions.pulse", 
+        "pulse train": "functions.pulse_train",
+        "ramp": "functions.ramp", 
+        "min": "np.minimum", 
+        "max": "np.maximum",
+        "active initial": "functions.active_initial", 
+        "xidz": "functions.xidz",
+        "zidz": "functions.zidz",
+        "game": "",  # In the future, may have an actual `functions.game` pass through
+
+        # vector functions
+        "vmin": "np.min", 
+        "vmax": "np.max", 
+        "prod": "np.prod"
+    }
+
+builders = {
+        "integ": lambda element, subscript_dict, args: builder.add_stock(
+                identifier = element['py_name'], 
+                subs = element['subs'], 
+                expression = args[0], 
+                initial_condition = args[1], 
+                subscript_dict = subscript_dict
+            ),
+
+        "delay1": lambda element, subscript_dict, args: builder.add_n_delay(
+                delay_input = args[0], 
+                delay_time = args[1], 
+                initial_value = args[0], 
+                order = '1', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "delay1i": lambda element, subscript_dict, args: builder.add_n_delay(
+                delay_input = args[0], 
+                delay_time = args[1], 
+                initial_value = args[2], 
+                order = '1', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "delay3": lambda element, subscript_dict, args: builder.add_n_delay(
+                delay_input = args[0], 
+                delay_time = args[1], 
+                initial_value = args[0], 
+                order = '3', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "delay3i": lambda element, subscript_dict, args: builder.add_n_delay(
+                delay_input = args[0], 
+                delay_time = args[1], 
+                initial_value = args[2], 
+                order = '3', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "delay n": lambda element, subscript_dict, args: builder.add_n_delay(
+                delay_input = args[0], 
+                delay_time = args[1], 
+                initial_value = args[2], 
+                order = args[3], 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "smooth": lambda element, subscript_dict, args: builder.add_n_smooth(
+                smooth_input = args[0], 
+                smooth_time = args[1], 
+                initial_value = args[0], 
+                order = '1', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "smoothi": lambda element, subscript_dict, args: builder.add_n_smooth(
+                smooth_input = args[0], 
+                smooth_time = args[1], 
+                initial_value = args[2], 
+                order = '1', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "smooth3": lambda element, subscript_dict, args: builder.add_n_smooth(
+                smooth_input = args[0], 
+                smooth_time = args[1], 
+                initial_value = args[0], 
+                order = '3', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "smooth3i": lambda element, subscript_dict, args: builder.add_n_smooth(
+                smooth_input = args[0], 
+                smooth_time = args[1], 
+                initial_value = args[2], 
+                order = '3', 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "smooth n": lambda element, subscript_dict, args: builder.add_n_smooth(
+                smooth_input = args[0], 
+                smooth_time = args[1], 
+                initial_value = args[2], 
+                order = args[3], 
+                subs = element['subs'], 
+                subscript_dict = subscript_dict
+            ),
+
+        "initial": lambda element, subscript_dict, args: builder.add_initial(args[0]),
+
+        "a function of": lambda element, subscript_dict, args: builder.add_incomplete(element['real_name'], args)
+    }
+    
 def parse_general_expression(element, namespace=None, subscript_dict=None, macro_list=None):
     """
     Parses a normal expression
@@ -364,66 +508,6 @@ def parse_general_expression(element, namespace=None, subscript_dict=None, macro
         namespace = {}
     if subscript_dict is None:
         subscript_dict = {}
-
-    functions = {
-        # element-wise functions
-        "abs": "abs", "integer": "int", "exp": "np.exp", "sin": "np.sin", "cos": "np.cos",
-        "sqrt": "np.sqrt", "tan": "np.tan", "lognormal": "np.random.lognormal",
-        "random normal": "functions.bounded_normal", "poisson": "np.random.poisson",
-        "ln": "np.log", "log": "functions.log",
-        "exprnd": "np.random.exponential", "random uniform": "functions.random_uniform",
-        "sum": "np.sum",
-        "arccos": "np.arccos", "arcsin": "np.arcsin", "arctan": "np.arctan",
-        "if then else": "functions.if_then_else", "step": "functions.step", "modulo": "np.mod",
-        "pulse": "functions.pulse", "pulse train": "functions.pulse_train",
-        "ramp": "functions.ramp", "min": "np.minimum", "max": "np.maximum",
-        "active initial": "functions.active_initial", "xidz": "functions.xidz",
-        "zidz": "functions.zidz",
-        "game": "",  # In the future, may have an actual `functions.game` pass through
-
-        # vector functions
-        "vmin": "np.min", "vmax": "np.max", "prod": "np.prod"
-    }
-
-    builders = {
-        "integ": lambda expr, init: builder.add_stock(
-            element['py_name'], element['subs'], expr, init, subscript_dict),
-
-        "delay1": lambda in_var, dtime: builder.add_n_delay(
-            in_var, dtime, '0', '1', element['subs'], subscript_dict),
-
-        "delay1i": lambda in_var, dtime, init: builder.add_n_delay(
-            in_var, dtime, init, '1', element['subs'], subscript_dict),
-
-        "delay3": lambda in_var, dtime: builder.add_n_delay(
-            in_var, dtime, '0', '3', element['subs'], subscript_dict),
-
-        "delay3i": lambda in_var, dtime, init: builder.add_n_delay(
-            in_var, dtime, init, '3', element['subs'], subscript_dict),
-
-        "delay n": lambda in_var, dtime, init, order: builder.add_n_delay(
-            in_var, dtime, init, order, element['subs'], subscript_dict),
-
-        "smooth": lambda in_var, dtime: builder.add_n_smooth(
-            in_var, dtime, '0', '1', element['subs'], subscript_dict),
-
-        "smoothi": lambda in_var, dtime, init: builder.add_n_smooth(
-            in_var, dtime, init, '1', element['subs'], subscript_dict),
-
-        "smooth3": lambda in_var, dtime: builder.add_n_smooth(
-            in_var, dtime, '0', '3', element['subs'], subscript_dict),
-
-        "smooth3i": lambda in_var, dtime, init: builder.add_n_smooth(
-            in_var, dtime, init, '3', element['subs'], subscript_dict),
-
-        "smooth n": lambda in_var, dtime, init, order: builder.add_n_smooth(
-            in_var, dtime, init, order, element['subs'], subscript_dict),
-
-        "initial": lambda initial_input: builder.add_initial(initial_input),
-
-        "a function of": lambda *args: builder.add_incomplete(
-            element['real_name'], args)
-    }
 
     in_ops = {
         "+": "+", "-": "-", "*": "*", "/": "/", "^": "**", "=": "==", "<=": "<=", "<>": "!=",
@@ -578,7 +662,9 @@ def parse_general_expression(element, namespace=None, subscript_dict=None, macro
             call = vc[0]
             arglist = vc[4]
             self.kind = 'component'
-            name, structure = builders[call.strip().lower()](*arglist)
+            
+            builder_name = call.strip().lower()
+            name, structure = builders[builder_name](element, subscript_dict, arglist)
             self.new_structure += structure
             return name
 

--- a/pysd/py_backend/xmile/SMILE2Py.py
+++ b/pysd/py_backend/xmile/SMILE2Py.py
@@ -65,18 +65,7 @@ functions = {
     "pulse": "functions.pulse_magnitude",
     "step": "functions.step",
     "ramp": "functions.ramp",
-    
-    # ===
-    # 3.5.5 Time Functions
-    # http://docs.oasis-open.org/xmile/xmile/v1.0/csprd01/xmile-v1.0-csprd01.html#_Toc398039984
-    # ===
-    # Should we include as function list or it provided by another way?
-    
-    # "dt" !TODO!
-    # "starttime" !TODO!
-    # "stoptime" !TODO!
-    # "time" !TODO!
-    
+       
     # ===
     # 3.5.6 Miscellaneous Functions
     # http://docs.oasis-open.org/xmile/xmile/v1.0/csprd01/xmile-v1.0-csprd01.html#_Toc398039985
@@ -150,7 +139,14 @@ class SMILEParser(NodeVisitor):
         self.extended_model_namespace = {
             key.replace(' ', '_'): value for key, value in self.model_namespace.items()}
         self.extended_model_namespace.update(self.model_namespace)
+        
+        # ===
+        # 3.5.5 Time Functions
+        # http://docs.oasis-open.org/xmile/xmile/v1.0/csprd01/xmile-v1.0-csprd01.html#_Toc398039984
+        # ===
         self.extended_model_namespace.update({'dt': 'time_step'})
+        self.extended_model_namespace.update({'starttime': 'initial_time'})
+        self.extended_model_namespace.update({'endtime': 'final_time'})
 
         grammar = pkg_resources.resource_string("pysd", "py_backend/xmile/smile.grammar")
         grammar = grammar.decode('ascii').format(

--- a/pysd/py_backend/xmile/SMILE2Py.py
+++ b/pysd/py_backend/xmile/SMILE2Py.py
@@ -105,16 +105,16 @@ infix_operators = {
 # ====
 
 builders = {
-    # !TODO! Should correct handle the last args, because it's optionally
+    # !TODO! Should correct handle the last args, should take the initial value of element instead the 0 if this parameter is missing
     # "delay" !TODO! How to add the infinity delay?
-    "delay1": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2], "1", element['subs'], subscript_dict),
-    "delay3": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2], "3", element['subs'], subscript_dict),
-    "delayn": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[3], args[2], element['subs'], subscript_dict),
+    "delay1": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2] if len(args) > 2 else 0, "1", element['subs'], subscript_dict),
+    "delay3": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2] if len(args) > 2 else 0, "3", element['subs'], subscript_dict),
+    "delayn": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2] if len(args) > 3 else 0, args[2], element['subs'], subscript_dict),
     
     # !TODO! Should correct handle the last args, because it's optionally
-    "smth1": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2], "1", element['subs'], subscript_dict),
-    "smth3": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2], "3", element['subs'], subscript_dict),
-    "smthn": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[3], args[2], element['subs'], subscript_dict),
+    "smth1": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2] if len(args) > 2 else 0, "1", element['subs'], subscript_dict),
+    "smth3": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2] if len(args) > 2 else 0, "3", element['subs'], subscript_dict),
+    "smthn": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2] if len(args) > 3 else 0, args[2], element['subs'], subscript_dict),
     
     # "forcst" !TODO!
     # "trend" !TODO!

--- a/pysd/py_backend/xmile/SMILE2Py.py
+++ b/pysd/py_backend/xmile/SMILE2Py.py
@@ -3,7 +3,7 @@ Created August 14 2014
 James Houghton <james.p.houghton@gmail.com>
 
 Changed May 03 2017
-Alexey Prey Mulyukin <alexprey@yandex.ru>
+Alexey Prey Mulyukin <alexprey@yandex.ru> from sdCloud.io developement team
     Changes:
     
     [May 03 2017] Alexey Prey Mulyukin: Integrate support to

--- a/pysd/py_backend/xmile/SMILE2Py.py
+++ b/pysd/py_backend/xmile/SMILE2Py.py
@@ -71,7 +71,6 @@ functions = {
     # http://docs.oasis-open.org/xmile/xmile/v1.0/csprd01/xmile-v1.0-csprd01.html#_Toc398039985
     # ===
     "if_then_else": "functions.if_then_else",
-    # "init" !TODO!
     # "previous" !TODO!
     # "self" !TODO!
 }
@@ -118,6 +117,8 @@ builders = {
     
     # "forcst" !TODO!
     # "trend" !TODO!
+    
+    "init": lambda element, subscript_dict, args: builder.add_initial(args[0]),
 }
 
 

--- a/pysd/py_backend/xmile/SMILE2Py.py
+++ b/pysd/py_backend/xmile/SMILE2Py.py
@@ -166,8 +166,10 @@ class SMILEParser(NodeVisitor):
                 If context is set to definition, lone identifiers will be cleaned and returned.
         """
         
-        # !TODO! Should remove the inline comments from `text` before parsing the grammar
+        # Remove the inline comments from `text` before parsing the grammar
         # http://docs.oasis-open.org/xmile/xmile/v1.0/csprd01/xmile-v1.0-csprd01.html#_Toc398039973
+        text = re.sub(r"\{[^}]*\}", "", text)
+        
         self.ast = self.grammar.parse(text)
         self.context = context
         self.element = element

--- a/pysd/py_backend/xmile/SMILE2Py.py
+++ b/pysd/py_backend/xmile/SMILE2Py.py
@@ -104,16 +104,61 @@ infix_operators = {
 # ====
 
 builders = {
-    # !TODO! Should correct handle the last args, should take the initial value of element instead the 0 if this parameter is missing
     # "delay" !TODO! How to add the infinity delay?
-    "delay1": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2] if len(args) > 2 else 0, "1", element['subs'], subscript_dict),
-    "delay3": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2] if len(args) > 2 else 0, "3", element['subs'], subscript_dict),
-    "delayn": lambda element, subscript_dict, args: builder.add_n_delay(args[0], args[1], args[2] if len(args) > 3 else 0, args[2], element['subs'], subscript_dict),
     
-    # !TODO! Should correct handle the last args, because it's optionally
-    "smth1": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2] if len(args) > 2 else 0, "1", element['subs'], subscript_dict),
-    "smth3": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2] if len(args) > 2 else 0, "3", element['subs'], subscript_dict),
-    "smthn": lambda element, subscript_dict, args: builder.add_n_smooth(args[0], args[1], args[2] if len(args) > 3 else 0, args[2], element['subs'], subscript_dict),
+    "delay1": lambda element, subscript_dict, args: builder.add_n_delay(
+            delay_input = args[0], 
+            delay_time = args[1], 
+            initial_value = args[2] if len(args) > 2 else args[0], 
+            order = "1", 
+            subs = element['subs'], 
+            subscript_dict = subscript_dict
+        ),
+        
+    "delay3": lambda element, subscript_dict, args: builder.add_n_delay(
+            delay_input = args[0], 
+            delay_time = args[1], 
+            initial_value = args[2] if len(args) > 2 else args[0], 
+            order = "3", 
+            subs = element['subs'], 
+            subscript_dict = subscript_dict
+        ),
+    
+    "delayn": lambda element, subscript_dict, args: builder.add_n_delay(
+            delay_input = args[0], 
+            delay_time = args[1], 
+            input_value = args[2] if len(args) > 3 else args[0], 
+            order = args[2], 
+            subs = element['subs'], 
+            subscript_dict = subscript_dict
+        ),
+    
+    "smth1": lambda element, subscript_dict, args: builder.add_n_smooth(
+            smooth_input = args[0], 
+            smooth_time = args[1], 
+            initial_value = args[2] if len(args) > 2 else args[0], 
+            order = "1", 
+            subs = element['subs'], 
+            subscript_dict = subscript_dict
+        ),
+    
+    "smth3": lambda element, subscript_dict, args: builder.add_n_smooth(
+            smooth_input = args[0], 
+            smooth_time = args[1], 
+            initial_value = args[2] if len(args) > 2 else args[0], 
+            order = "3", 
+            subs = element['subs'], 
+            subscript_dict = subscript_dict
+        ),
+    
+    "smthn": lambda element, subscript_dict, args: builder.add_n_smooth(
+            smooth_input = args[0], 
+            smooth_time = args[1], 
+            initial_value = args[2] if len(args) > 3 else args[0], 
+            order = args[2], 
+            subs = element['subs'], 
+            subscript_dict = subscript_dict
+        ),
     
     # "forcst" !TODO!
     # "trend" !TODO!

--- a/pysd/py_backend/xmile/smile.grammar
+++ b/pysd/py_backend/xmile/smile.grammar
@@ -2,10 +2,10 @@ expr = conditional_statement / (_ pre_oper? _ primary _ (in_oper _ expr)?)
 
 conditional_statement = "IF" _ expr _ "THEN" _ expr _ "ELSE" _ expr
 
-primary  = call / parens / number / identifier
+primary  = call / build_call / parens / number / identifier
 parens   = "(" _ expr _ ")"
-call     = func _ "(" _ (expr _ ","? _)* _ ")"
-build_call = build_keyword _ "(" arguments ")"
+call     = func _ "(" _ arguments _ ")"
+build_call = build_keyword _ "(" _ arguments _ ")"
 arguments = (expr _ ","? _)*
 
 number   = ((~"[0-9]"+ "."? ~"[0-9]"*) / ("." ~"[0-9]"+)) (("e"/"E") ("-"/"+") ~"[0-9]"+)?

--- a/pysd/py_backend/xmile/xmile2py.py
+++ b/pysd/py_backend/xmile/xmile2py.py
@@ -94,14 +94,14 @@ def translate_xmile(xmile_file):
 
         py_inflows = []
         for inputFlow in inflows:
-            tranlation, new_structure = smile_parser.parse(inputFlow, element)
-            py_inflows.append(tranlation['py_expr'])
+            translation, new_structure = smile_parser.parse(inputFlow, element)
+            py_inflows.append(translation['py_expr'])
             model_elements += new_structure
         
         py_outflows = []
         for outputFlow in outflows:
-            tranlation, new_structure = smile_parser.parse(outputFlow, element)
-            py_outflows.append(tranlation['py_expr'])
+            translation, new_structure = smile_parser.parse(outputFlow, element)
+            py_outflows.append(translation['py_expr'])
             model_elements += new_structure
         
         py_ddt = ' + '.join(py_inflows) if py_inflows else ''
@@ -109,7 +109,7 @@ def translate_xmile(xmile_file):
 
         initial_value = get_xpath_text(node, 'ns:eqn')
         translation, new_structure = smile_parser.parse(initial_value, element)
-        py_initial_value = tranlation['py_expr']
+        py_initial_value = translation['py_expr']
         model_elements += new_structure
 
         py_expr, new_structure = builder.add_stock(identifier=py_name,

--- a/pysd/py_backend/xmile/xmile2py.py
+++ b/pysd/py_backend/xmile/xmile2py.py
@@ -126,7 +126,7 @@ def translate_xmile(xmile_file):
     # remove timestamp pieces so as not to double-count
     model_elements_parsed = []
     for element in model_elements:
-        if element['real_name'].lower() not in ['initial time', 'final time', 'time step']:
+        if element['real_name'].lower() not in ['initial time', 'final time', 'time step', 'saveper']:
             model_elements_parsed.append(element)
     model_elements = model_elements_parsed
 

--- a/pysd/py_backend/xmile/xmile2py.py
+++ b/pysd/py_backend/xmile/xmile2py.py
@@ -3,7 +3,7 @@ Deals with accessing the components of the xmile file, and
 formatting them for the builder
 
 James Houghton <james.p.houghton@gmail.com>
-Alexey Prey Mulyukin
+Alexey Prey Mulyukin <alexprey@yandex.ru> from sdCloud.io development team.
 
 """
 from __future__ import absolute_import
@@ -162,7 +162,17 @@ def translate_xmile(xmile_file):
         'arguments': '',
     })
 
-    # Todo: Saveper
+    model_elements.append({
+        'kind': 'constant',
+        'real_name': 'SAVE PER',
+        'unit': time_units,
+        'doc': 'The time step for the simulation results.',
+        'eqn': dt,
+        'py_name': 'saveper',
+        'subs': None,
+        'py_expr': py_dt,
+        'arguments': ''
+    })
 
     outfile_name = xmile_file.replace('.xmile', '.py')
 

--- a/pysd/py_backend/xmile/xmile2py.py
+++ b/pysd/py_backend/xmile/xmile2py.py
@@ -30,6 +30,13 @@ def translate_xmile(xmile_file):
             return node.xpath(path, namespaces=ns)[0].text
         except:
             return default
+            
+    def is_constant_expression(py_expr):
+        try:
+            val = float(py_expr)
+            return True
+        except ValueError:
+            return False
 
     # build model namespace
     namespace = {
@@ -58,7 +65,7 @@ def translate_xmile(xmile_file):
         eqn = get_xpath_text(node, 'ns:eqn')
         
         element = {
-            'kind': 'component',  # Not always the case - could be constant!
+            'kind': 'component',
             'real_name': name,
             'unit': units,
             'doc': doc,
@@ -70,6 +77,9 @@ def translate_xmile(xmile_file):
                 
         tranlation, new_structure = smile_parser.parse(eqn, element)
         element.update(tranlation)
+        if is_constant_expression(element['py_expr']):
+            element['kind'] = 'constant'
+        
         model_elements += new_structure
         model_elements.append(element)
 
@@ -89,7 +99,7 @@ def translate_xmile(xmile_file):
         eqn += (' - ' + ' - '.join(outflows)) if outflows else ''
         
         element = {
-            'kind': 'component',  # Not always the case - could be constant!
+            'kind': 'component' if inflows or outflows else 'constant',
             'real_name': name,
             'unit': units,
             'doc': doc,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ lxml
 xlwt
 funcsigs
 pydoe
+xlrd


### PR DESCRIPTION
Continue working on xmile support for latest version of PySD.

This PR introduce many fixes and implementations for XMILE specification into PYSD:

- Fix executing the XMILE models
- Implement `delay*` and `smth*` functions
- Implement `INIT` statement
- Implement `STARTTIME` and `STOPTIME` functions
- Implement supporting for in-line comments into XMILE equations

Also I'm introduce small fixes into package for fix issues.

Known issues:

- `MACRO` is not supported
- `LOOKUP` is not supported
- Functions `forcst`, `trend` and `delay` is not supported at now
- Functions `previous` and `self` is not supported
- Functions `delay*` and `smth*` has wrong behaviour for optional `initial_value` parameter. Works like in vensim, use the `0` value instead the initial value of input stock

------
Alexey from sdCloud.io development team