### PR TITLE
correct parsing (the ranges are not mandatory in vensim lookup table)

### DIFF
--- a/pysd/py_backend/vensim/vensim2py.py
+++ b/pysd/py_backend/vensim/vensim2py.py
@@ -748,9 +748,10 @@ def parse_lookup_expression(element):
     """ This syntax parses lookups that are defined with their own element """
 
     lookup_grammar = r"""
-    lookup = _ "(" _ "[" ~r"[^\]]*" "]" _ "," _ ( "(" _ number _ "," _ number _ ")" _ ","? _ )+ ")"
+    lookup = _ "(" range? _ ( "(" _ number _ "," _ number _ ")" _ ","? _ )+ ")"
     number = ("+"/"-")? ~r"\d+\.?\d*(e[+-]\d+)?"
     _ = ~r"[\s\\]*"  # whitespace character
+	range = _ "[" ~r"[^\]]*" "]" _ ","
     """
     parser = parsimonious.Grammar(lookup_grammar)
     tree = parser.parse(element['expr'])
@@ -766,7 +767,7 @@ def parse_lookup_expression(element):
             return ''
 
         def visit_lookup(self, n, vc):
-            pairs = vc[9]
+            pairs = max(vc, key=len)
             mixed_list = pairs.replace('(', '').replace(')', '').split(',')
             xs = mixed_list[::2]
             ys = mixed_list[1::2]

--- a/tests/integration_test_vensim_pathway.py
+++ b/tests/integration_test_vensim_pathway.py
@@ -133,7 +133,7 @@ class TestIntegrationExamples(unittest.TestCase):
         
     def test_lookups_without_range(self):
         from.test_utils import runner, assert_frames_close
-        output, canon = runner('test-models/tests/lookups/test_lookups_without_range.mdl')
+        output, canon = runner('test-models/tests/lookups_without_range/test_lookups_without_range.mdl')
         assert_frames_close(output, canon, rtol=rtol)
 
     def test_lookups_funcnames(self):

--- a/tests/integration_test_vensim_pathway.py
+++ b/tests/integration_test_vensim_pathway.py
@@ -130,6 +130,11 @@ class TestIntegrationExamples(unittest.TestCase):
         from.test_utils import runner, assert_frames_close
         output, canon = runner('test-models/tests/lookups/test_lookups.mdl')
         assert_frames_close(output, canon, rtol=rtol)
+        
+    def test_lookups_without_range(self):
+        from.test_utils import runner, assert_frames_close
+        output, canon = runner('test-models/tests/lookups/test_lookups_without_range.mdl')
+        assert_frames_close(output, canon, rtol=rtol)
 
     def test_lookups_funcnames(self):
         from.test_utils import runner, assert_frames_close


### PR DESCRIPTION
I ported the World3 model, I needed to do this change to make it successful... It may be incorrect, please suggest another solution if needed.