### PR TITLE
Fix issue #199. Change logic to build a result file name in xmile-py …

### DIFF
--- a/pysd/py_backend/xmile/xmile2py.py
+++ b/pysd/py_backend/xmile/xmile2py.py
@@ -11,6 +11,7 @@ from .SMILE2Py import SMILEParser
 from lxml import etree
 from ...py_backend import builder, utils
 
+import os.path
 import numpy as np
 
 def translate_xmile(xmile_file):
@@ -327,7 +328,10 @@ def translate_xmile(xmile_file):
         'arguments': '',
     })
 
-    outfile_name = xmile_file.replace('.xmile', '.py')
+    file_name, file_extension = os.path.splitext(xmile_file)
+    base_dir = os.path.dirname(xmile_file)
+
+    outfile_name = base_dir + os.path.sep + file_name + '.py'
 
     builder.build(elements=model_elements,
                   subscript_dict={},

--- a/pysd/py_backend/xmile/xmile2py.py
+++ b/pysd/py_backend/xmile/xmile2py.py
@@ -329,9 +329,8 @@ def translate_xmile(xmile_file):
     })
 
     file_name, file_extension = os.path.splitext(xmile_file)
-    base_dir = os.path.dirname(xmile_file)
 
-    outfile_name = base_dir + os.path.sep + file_name + '.py'
+    outfile_name = file_name + '.py'
 
     builder.build(elements=model_elements,
                   subscript_dict={},


### PR DESCRIPTION
Change logic to build a result file name in xmile-py transpiler.
Previously method just replace `.xmile` entries in file path to `.py`, it can lead to errors when resulting file name contains one more `.xmile` entries or don't contains any entries, f.ex. in when runnning for `.stmx` models.

My sugestion to use another algorithm: takes the base file name w/o file extension and add to them `.py` extension. This approach should be more safer.