### PR TITLE
Fix indent issue 234

### DIFF
--- a/pysd/py_backend/builder.py
+++ b/pysd/py_backend/builder.py
@@ -239,7 +239,8 @@ def build_element(element, subscript_dict):
                                                  '\n' + ' ' * indent)})
                                                  # indent lines 2 onward
 
-    element['doc'] = element['doc'].replace('\\', '\n    ')
+    # convert newline indicator and add expected level of indentation
+    element['doc'] = element['doc'].replace('\\', '\n').replace('\n', '\n    ')
 
     if element['kind'] in ['stateful', 'external']:
         func = '''
@@ -284,6 +285,8 @@ def build_element(element, subscript_dict):
         """
         %(contents)s
         ''' % element
+
+    func = textwrap.dedent(func)
 
     return func
 

--- a/pysd/py_backend/builder.py
+++ b/pysd/py_backend/builder.py
@@ -70,7 +70,8 @@ def build(elements, subscript_dict, namespace, outfile_name):
     Python model "%(outfile)s"
     Translated using PySD version %(version)s
     """
-    from os import path\n'''
+    from os import path\n''' % {'outfile': os.path.basename(outfile_name),
+                                'version': __version__}
 
     # intelligent import of needed functions and packages
     if import_modules['numpy']:

--- a/pysd/py_backend/builder.py
+++ b/pysd/py_backend/builder.py
@@ -117,22 +117,25 @@ def build(elements, subscript_dict, namespace, outfile_name):
     def time():
         return __data['time']()
 
-    %(functions)s
-
     ''' % {'subscript_dict': repr(subscript_dict),
-           'functions': '\n'.join(functions),
            'namespace': repr(namespace),
            'outfile': os.path.basename(outfile_name),
            'version': __version__}
-
+    
     text = text.replace('\t', '    ')
-    text = black.format_file_contents(textwrap.dedent(text), fast=True,
+    text = textwrap.dedent(text)
+
+    funcs = "%(functions)s" % {'functions': '\n'.join(functions)}
+    funcs = funcs.replace('\t', '    ')
+    text += funcs
+
+    text = black.format_file_contents(text, fast=True,
                                       mode=black.FileMode())
 
     # this is needed if more than one model are translated in the same session
     build_names.clear()
     for module in ['numpy', 'xarray', 'subs']:
-        import_modules[module] =False
+        import_modules[module] = False
     for module in ['functions', 'external', 'utils']:
         import_modules[module].clear()
 


### PR DESCRIPTION
Fix for #234
Relies on #233 to have been merged.

Black formatter does not like extra level of indentation, even if it is uniformly applied to the file.

A call to `textwrap.dedent()` did not work as expected, and blanket removal of initial indentation is dangerous (see discussion in #234).

Issue appears to have been caused by function definitions including docstrings that have mixed level of indentation.

```python
    # note this has an extra-level of indentation
    def some_func():
        """
        something: some text
http://some_url   <-  this un-indented line causes dedentation to fail
        """
        pass
```

This also confuses `textwrap.dedent()` as it assumes an extra level of indentation is intended.

Solved by:

1. Enforcing 1 level of indent after newlines in docstrings (see change L242 in `builder.py`)
2. Subsequent formatting of function definitions to remove extra level of indentation (see L289 in `builder.py`)
3. Dedenting top of file separately from function definitions


I will add tests to the test file created as part of #233 once that is merged.